### PR TITLE
Reduce scala classname length

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -14,6 +14,7 @@ object BuildSettings extends Build {
     parallelExecution in Global := false,
     traceLevel   := 50,
     scalacOptions ++= Seq("-deprecation","-unchecked"),
+    scalacOptions ++= Seq("-Xmax-classfile-name", "72"),
     libraryDependencies ++= Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
   )
 


### PR DESCRIPTION
When running in an ecryptfs-encrypted directory, the underlying
filenames become too long for ext4 (and most probably others). Chisel
than exits with "File name too long". Reducing the classname length
fixes this.