### PR TITLE
Fix dpi_ram_behav.cpp compilation problem

### DIFF
--- a/src/test/cxx/common/dpi_ram_behav.cpp
+++ b/src/test/cxx/common/dpi_ram_behav.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <algorithm>
 #include <fstream>
+#include <iostream>
 #include <boost/lexical_cast.hpp>
 #include <boost/format.hpp>
 


### PR DESCRIPTION
Add missing #include<iostream>