### PR TITLE
Various fixes to set_env.sh

### DIFF
--- a/set_env.sh
+++ b/set_env.sh
@@ -4,7 +4,7 @@ echo "Setting up lowRISC/RISC-V and SoC Debug SoC environment..."
 echo "Make sure you source this script at the top of lowrisc-chip."
 
 # Variables for lowRISC/RISC-V
-if [ ! -d $TOP ]; then
+if [ -z $TOP ] || [ ! -d $TOP ]; then
     echo "\$TOP is not defined or does not point to a directory."
     echo "Set \$TOP to the top of lowrisc-chip which is the current directory."
     export TOP=$PWD
@@ -25,13 +25,19 @@ if [ -z $OSD_ROOT ]; then
     export OSD_ROOT=$TOP/tools
 fi
 
-if [ -z $LD_LIBRARY_PATH ]; then export LD_LIBRARY_PATH=$OSD_ROOT/lib
-else export LD_LIBRARY_PATH=$OSD_ROOT/lib:$LD_LIBRARY_PATH; fi
+if [ -z $LD_LIBRARY_PATH ]; then
+  export LD_LIBRARY_PATH=$OSD_ROOT/lib
+else
+  export LD_LIBRARY_PATH=$OSD_ROOT/lib:$LD_LIBRARY_PATH
+fi
 
 export PATH=$OSD_ROOT/bin:$PATH
 
-if [ -z $PKG_CONFIG_PATH ]; then export PKG_CONFIG_PATH=$OSD_ROOT/lib/pkgconfig
-else export PKG_CONFIG_PATH=$OSD_ROOT/lib/pkgconfig:$PKG_CONFIG_PATH; fi
+if [ -z $PKG_CONFIG_PATH ]; then
+  export PKG_CONFIG_PATH=$OSD_ROOT/lib/pkgconfig
+else
+  export PKG_CONFIG_PATH=$OSD_ROOT/lib/pkgconfig:$PKG_CONFIG_PATH
+fi
 
 # choose the FPGA board (Nexys4-DDR in default)
 if [ -z $FPGA_BOARD ]; then


### PR DESCRIPTION
The primary issue was that `[ ! -d $UNDEFVAR ]` is always false, meaning that
$TOP wouldn't be set. I've adjusted the conditional and also taken the
opportunity to ensure that all arguments to `[` are quoted, to avoid issues in
the cases the directory contains a space. Additionally, I've reformatted the
opensocdebug related lines to use more conventional indentation which matches
the rest of the file.