### PR TITLE
Merge hardware support for nexys4_video into update branch

### DIFF
--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -426,6 +426,12 @@ class With128MRamConfig extends Config (
   }
 )
 
+class With512MRamConfig extends Config (
+  (pname,site,here) => pname match {
+    case RAMSize => BigInt(1L << 29)  // 512 MB
+  }
+)
+
 class FPGAConfig extends
     Config(new WithUARTConfig ++ new WithSPIConfig ++ new WithBootRAMConfig ++ new BaseConfig)
 
@@ -437,4 +443,10 @@ class Nexys4Config extends
 
 class Nexys4DebugConfig extends
     Config(new With128MRamConfig ++ new FPGADebugConfig)
+
+class Nexys4VideoConfig extends
+    Config(new With512MRamConfig ++ new FPGAConfig)
+
+class Nexys4VideoDebugConfig extends
+    Config(new With512MRamConfig ++ new FPGADebugConfig)
 

--- a/src/main/verilog/chip_top.sv
+++ b/src/main/verilog/chip_top.sv
@@ -26,6 +26,23 @@ module chip_top
    output        ddr_cs_n,
    output [7:0]  ddr_dm,
    output        ddr_odt,
+ `elsif NEXYS4_VIDEO
+   // DDR3 RAM
+     inout [15:0]  ddr_dq,
+     inout [1:0]   ddr_dqs_n,
+     inout [1:0]   ddr_dqs_p,
+     output [14:0] ddr_addr,
+     output [2:0]  ddr_ba,
+     output        ddr_ras_n,
+     output        ddr_cas_n,
+     output        ddr_we_n,
+     output        ddr_reset_n,
+     output        ddr_ck_n,
+     output        ddr_ck_p,
+     output        ddr_cke,
+     output [1:0]  ddr_dm,
+     output        ddr_odt,
+     output        init_calib_complete,
  `elsif NEXYS4
    // DDR2 RAM
    inout [15:0]  ddr_dq,
@@ -203,6 +220,18 @@ module chip_top
       .m_axi_rready         ( mem_mig_nasti.r_ready    )
       );
 
+ `ifdef NEXYS4_VIDEO
+   //clock generator
+   logic mig_sys_clk, clk_locked;
+   clk_wiz_0 clk_gen
+     (
+      .clk_in1     ( clk_p         ), // 100 MHz onboard
+      .clk_out1    ( mig_sys_clk   ), // 200 MHz
+      .reset       ( rst_top       ), // Active HIGH reset !
+      .locked      ( clk_locked    )
+      );
+ `endif
+
  `ifdef NEXYS4
    //clock generator
    logic mig_sys_clk, clk_locked;
@@ -238,6 +267,27 @@ module chip_top
       .ddr3_cs_n            ( ddr_cs_n               ),
       .ddr3_dm              ( ddr_dm                 ),
       .ddr3_odt             ( ddr_odt                ),
+ `elsif NEXYS4_VIDEO
+     // System Clock Ports
+     .sys_clk_i                      (mig_sys_clk),
+     .sys_rst                        (clk_locked), // input sys_rst
+     .ui_addn_clk_0                  (clk),
+     // Memory interface ports
+     .ddr3_addr                      (ddr_addr),  // output [14:0]        ddr3_addr
+     .ddr3_ba                        (ddr_ba),  // output [2:0]        ddr3_ba
+     .ddr3_cas_n                     (ddr_cas_n),  // output            ddr3_cas_n
+     .ddr3_ck_n                      (ddr_ck_n),  // output [0:0]        ddr3_ck_n
+     .ddr3_ck_p                      (ddr_ck_p),  // output [0:0]        ddr3_ck_p
+     .ddr3_cke                       (ddr_cke),  // output [0:0]        ddr3_cke
+     .ddr3_ras_n                     (ddr_ras_n),  // output            ddr3_ras_n
+     .ddr3_reset_n                   (ddr_reset_n),  // output            ddr3_reset_n
+     .ddr3_we_n                      (ddr_we_n),  // output            ddr3_we_n
+     .ddr3_dq                        (ddr_dq),  // inout [15:0]        ddr3_dq
+     .ddr3_dqs_n                     (ddr_dqs_n),  // inout [1:0]        ddr3_dqs_n
+     .ddr3_dqs_p                     (ddr_dqs_p),  // inout [1:0]        ddr3_dqs_p
+     .init_calib_complete            (init_calib_complete),  // output   init_calib_complete
+     .ddr3_dm                        (ddr_dm),  // output [1:0]        ddr3_dm
+     .ddr3_odt                       (ddr_odt),  // output [0:0]        ddr3_odt
  `elsif NEXYS4
       .sys_clk_i            ( mig_sys_clk            ),
       .sys_rst              ( clk_locked             ),

--- a/src/main/verilog/chip_top.sv
+++ b/src/main/verilog/chip_top.sv
@@ -42,7 +42,6 @@ module chip_top
      output        ddr_cke,
      output [1:0]  ddr_dm,
      output        ddr_odt,
-     output        init_calib_complete,
  `elsif NEXYS4
    // DDR2 RAM
    inout [15:0]  ddr_dq,
@@ -221,18 +220,13 @@ module chip_top
       );
 
  `ifdef NEXYS4_VIDEO
-   //clock generator
-   logic mig_sys_clk, clk_locked;
-   clk_wiz_0 clk_gen
-     (
-      .clk_in1     ( clk_p         ), // 100 MHz onboard
-      .clk_out1    ( mig_sys_clk   ), // 200 MHz
-      .reset       ( rst_top       ), // Active HIGH reset !
-      .locked      ( clk_locked    )
-      );
+  `define CLK_WIZ_0
+ `endif
+ `ifdef NEXYS4
+  `define CLK_WIZ_0
  `endif
 
- `ifdef NEXYS4
+ `ifdef CLK_WIZ_0   
    //clock generator
    logic mig_sys_clk, clk_locked;
    clk_wiz_0 clk_gen
@@ -242,7 +236,7 @@ module chip_top
       .resetn      ( rst_top       ),
       .locked      ( clk_locked    )
       );
- `endif //  `ifdef NEXYS4
+ `endif //  `ifdef CLK_WIZ_0
 
    // DRAM controller
    mig_7series_0 dram_ctl
@@ -285,7 +279,7 @@ module chip_top
      .ddr3_dq                        (ddr_dq),  // inout [15:0]        ddr3_dq
      .ddr3_dqs_n                     (ddr_dqs_n),  // inout [1:0]        ddr3_dqs_n
      .ddr3_dqs_p                     (ddr_dqs_p),  // inout [1:0]        ddr3_dqs_p
-     .init_calib_complete            (init_calib_complete),  // output   init_calib_complete
+     .init_calib_complete            (),  // output   init_calib_complete
      .ddr3_dm                        (ddr_dm),  // output [1:0]        ddr3_dm
      .ddr3_odt                       (ddr_odt),  // output [0:0]        ddr3_odt
  `elsif NEXYS4

--- a/src/test/verilog/chip_top_tb.sv
+++ b/src/test/verilog/chip_top_tb.sv
@@ -34,7 +34,11 @@ module tb;
 
    initial begin
       clk = 0;
+  `ifdef KC705
       forever clk = #2.5 !clk;
+  `else
+      forever clk = #5 !clk;
+  `endif
    end // initial begin
 
 `ifdef FPGA
@@ -82,6 +86,50 @@ module tb;
                 );
       end
    endgenerate
+  `elsif NEXYS4_VIDEO
+   // DDRAM3
+   wire [15:0]  ddr_dq;
+   wire [1:0]   ddr_dqs_n;
+   wire [1:0]   ddr_dqs_p;
+   logic [14:0] ddr_addr;
+   logic [2:0]  ddr_ba;
+   logic        ddr_ras_n;
+   logic        ddr_cas_n;
+   logic        ddr_we_n;
+   logic        ddr_reset_n;
+   logic        ddr_ck_p;
+   logic        ddr_ck_n;
+   logic        ddr_cke;
+   logic        ddr_cs_n;
+   wire [1:0]   ddr_dm;
+   logic        ddr_odt;
+   wire 	init_calib_complete;
+   
+   // behavioural DDR3 RAM
+   genvar       i;
+   generate
+      for (i = 0; i < 2; i = i + 1) begin: gen_mem
+         ddr3_model u_comp_ddr3
+               (
+                .rst_n   ( ddr_reset_n     ),
+                .ck      ( ddr_ck_p        ),
+                .ck_n    ( ddr_ck_n        ),
+                .cke     ( ddr_cke         ),
+                .cs_n    ( ddr_cs_n        ),
+                .ras_n   ( ddr_ras_n       ),
+                .cas_n   ( ddr_cas_n       ),
+                .we_n    ( ddr_we_n        ),
+                .dm_tdqs ( ddr_dm[i]       ),
+                .ba      ( ddr_ba          ),
+                .addr    ( ddr_addr        ),
+                .dq      ( ddr_dq[8*i +:8] ),
+                .dqs     ( ddr_dqs_p[i]    ),
+                .dqs_n   ( ddr_dqs_n[i]    ),
+                .tdqs_n  (                 ),
+                .odt     ( ddr_odt         )
+                );
+      end
+   endgenerate   
   `elsif NEXYS4
    wire [15:0]  ddr_dq;
    wire [1:0]   ddr_dqs_n;

--- a/src/test/verilog/chip_top_tb.sv
+++ b/src/test/verilog/chip_top_tb.sv
@@ -14,7 +14,13 @@ module tb;
          .clk_p(clk),
          .clk_n(!clk),
 `ifdef FPGA_FULL
+ `ifdef NEXYS4_VIDEO
+  `define CLK_WIZ_0
+ `endif
  `ifdef NEXYS4
+  `define CLK_WIZ_0
+ `endif
+ `ifdef CLK_WIZ_0
          .rst_top(!rst)         // NEXYS4's cpu_reset is active low
  `else
          .rst_top(rst)
@@ -103,7 +109,6 @@ module tb;
    logic        ddr_cs_n;
    wire [1:0]   ddr_dm;
    logic        ddr_odt;
-   wire 	init_calib_complete;
    
    // behavioural DDR3 RAM
    genvar       i;

--- a/vsim/Makefile
+++ b/vsim/Makefile
@@ -107,7 +107,7 @@ test_cxx_headers = \
 # Build Verilog
 #--------------------------------------------------------------------
 
-verilog: $(lowrisc_srcs)
+verilog: $(lowrisc_srcs) $(lowrisc_headers)
 
 include $(base_dir)/Makefrag-build
 


### PR DESCRIPTION
nexys4_video needs several changes, such as 512M instead of 128M, DDR3 instead of DDR2, clk conversion ratio of 4:1 instead of 2:1, and a different sd card pinout.
