### PR TITLE
refactor verilog macro and indetion

### DIFF
--- a/src/main/verilog/chip_top.sv
+++ b/src/main/verilog/chip_top.sv
@@ -28,20 +28,20 @@ module chip_top
    output        ddr_odt,
  `elsif NEXYS4_VIDEO
    // DDR3 RAM
-     inout [15:0]  ddr_dq,
-     inout [1:0]   ddr_dqs_n,
-     inout [1:0]   ddr_dqs_p,
-     output [14:0] ddr_addr,
-     output [2:0]  ddr_ba,
-     output        ddr_ras_n,
-     output        ddr_cas_n,
-     output        ddr_we_n,
-     output        ddr_reset_n,
-     output        ddr_ck_n,
-     output        ddr_ck_p,
-     output        ddr_cke,
-     output [1:0]  ddr_dm,
-     output        ddr_odt,
+   inout [15:0]  ddr_dq,
+   inout [1:0]   ddr_dqs_n,
+   inout [1:0]   ddr_dqs_p,
+   output [14:0] ddr_addr,
+   output [2:0]  ddr_ba,
+   output        ddr_ras_n,
+   output        ddr_cas_n,
+   output        ddr_we_n,
+   output        ddr_reset_n,
+   output        ddr_ck_n,
+   output        ddr_ck_p,
+   output        ddr_cke,
+   output [1:0]  ddr_dm,
+   output        ddr_odt,
  `elsif NEXYS4
    // DDR2 RAM
    inout [15:0]  ddr_dq,
@@ -209,14 +209,7 @@ module chip_top
       .m_axi_rready         ( mem_mig_nasti.r_ready    )
       );
 
- `ifdef NEXYS4_VIDEO
-  `define CLK_WIZ_0
- `endif
- `ifdef NEXYS4
-  `define CLK_WIZ_0
- `endif
-
- `ifdef CLK_WIZ_0   
+ `ifdef NEXYS4_COMMON
    //clock generator
    logic mig_sys_clk, clk_locked;
    clk_wiz_0 clk_gen
@@ -226,7 +219,7 @@ module chip_top
       .resetn      ( rst_top       ),
       .locked      ( clk_locked    )
       );
- `endif //  `ifdef CLK_WIZ_0
+ `endif //  `ifdef NEXYS4_COMMON
 
    // DRAM controller
    mig_7series_0 dram_ctl
@@ -252,26 +245,23 @@ module chip_top
       .ddr3_dm              ( ddr_dm                 ),
       .ddr3_odt             ( ddr_odt                ),
  `elsif NEXYS4_VIDEO
-     // System Clock Ports
-     .sys_clk_i                      (mig_sys_clk),
-     .sys_rst                        (clk_locked), // input sys_rst
-     .ui_addn_clk_0                  (clk),
-     // Memory interface ports
-     .ddr3_addr                      (ddr_addr),  // output [14:0]        ddr3_addr
-     .ddr3_ba                        (ddr_ba),  // output [2:0]        ddr3_ba
-     .ddr3_cas_n                     (ddr_cas_n),  // output            ddr3_cas_n
-     .ddr3_ck_n                      (ddr_ck_n),  // output [0:0]        ddr3_ck_n
-     .ddr3_ck_p                      (ddr_ck_p),  // output [0:0]        ddr3_ck_p
-     .ddr3_cke                       (ddr_cke),  // output [0:0]        ddr3_cke
-     .ddr3_ras_n                     (ddr_ras_n),  // output            ddr3_ras_n
-     .ddr3_reset_n                   (ddr_reset_n),  // output            ddr3_reset_n
-     .ddr3_we_n                      (ddr_we_n),  // output            ddr3_we_n
-     .ddr3_dq                        (ddr_dq),  // inout [15:0]        ddr3_dq
-     .ddr3_dqs_n                     (ddr_dqs_n),  // inout [1:0]        ddr3_dqs_n
-     .ddr3_dqs_p                     (ddr_dqs_p),  // inout [1:0]        ddr3_dqs_p
-     .init_calib_complete            (),  // output   init_calib_complete
-     .ddr3_dm                        (ddr_dm),  // output [1:0]        ddr3_dm
-     .ddr3_odt                       (ddr_odt),  // output [0:0]        ddr3_odt
+      .sys_clk_i            ( mig_sys_clk            ),
+      .sys_rst              ( clk_locked             ),
+      .ui_addn_clk_0        ( clk                    ),
+      .ddr3_addr            ( ddr_addr               ),
+      .ddr3_ba              ( ddr_ba                 ),
+      .ddr3_cas_n           ( ddr_cas_n              ),
+      .ddr3_ck_n            ( ddr_ck_n               ),
+      .ddr3_ck_p            ( ddr_ck_p               ),
+      .ddr3_cke             ( ddr_cke                ),
+      .ddr3_ras_n           ( ddr_ras_n              ),
+      .ddr3_reset_n         ( ddr_reset_n            ),
+      .ddr3_we_n            ( ddr_we_n               ),
+      .ddr3_dq              ( ddr_dq                 ),
+      .ddr3_dqs_n           ( ddr_dqs_n              ),
+      .ddr3_dqs_p           ( ddr_dqs_p              ),
+      .ddr3_dm              ( ddr_dm                 ),
+      .ddr3_odt             ( ddr_odt                ),
  `elsif NEXYS4
       .sys_clk_i            ( mig_sys_clk            ),
       .sys_rst              ( clk_locked             ),

--- a/src/main/verilog/config.vh
+++ b/src/main/verilog/config.vh
@@ -53,6 +53,14 @@
    `define ADD_PHY_DDR
   `endif
 
- `endif
+  `ifdef NEXYS4_VIDEO
+   `define NEXYS4_COMMON
+  `endif
+
+  `ifdef NEXYS4
+   `define NEXYS4_COMMON
+  `endif
+
+`endif
 
 `endif

--- a/src/test/verilog/chip_top_tb.sv
+++ b/src/test/verilog/chip_top_tb.sv
@@ -14,13 +14,7 @@ module tb;
          .clk_p(clk),
          .clk_n(!clk),
 `ifdef FPGA_FULL
- `ifdef NEXYS4_VIDEO
-  `define CLK_WIZ_0
- `endif
- `ifdef NEXYS4
-  `define CLK_WIZ_0
- `endif
- `ifdef CLK_WIZ_0
+ `ifdef NEXYS4_COMMON
          .rst_top(!rst)         // NEXYS4's cpu_reset is active low
  `else
          .rst_top(rst)

--- a/src/test/verilog/chip_top_tb.sv
+++ b/src/test/verilog/chip_top_tb.sv
@@ -1,5 +1,7 @@
 // See LICENSE for license details.
 
+`include "consts.vh"
+
 module tb;
 
    logic clk, rst;


### PR DESCRIPTION
Avoid define the same macro in both chip_top_tb and chip_top.
Fix some indention.

Please rerun FPGA tests and I will try again.