### PR TITLE
UART flow control and Verilator compilation speed-up

### DIFF
--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -438,6 +438,12 @@ class With128MRamConfig extends Config (
   }
 )
 
+class With512MRamConfig extends Config (
+  (pname,site,here) => pname match {
+    case RAMSize => BigInt(1L << 29)  // 512 MB
+  }
+)
+
 class BasicFPGAConfig extends
     Config(new WithSPIConfig ++ new WithBootRAMConfig ++ new WithFlashConfig ++ new BaseConfig)
 
@@ -452,4 +458,10 @@ class Nexys4Config extends
 
 class Nexys4DebugConfig extends
     Config(new With128MRamConfig ++ new FPGADebugConfig)
+
+class Nexys4VideoConfig extends
+    Config(new With512MRamConfig ++ new FPGAConfig)
+
+class Nexys4VideoDebugConfig extends
+    Config(new With512MRamConfig ++ new FPGADebugConfig)
 

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -40,7 +40,7 @@ class BaseConfig extends Config (
         Dump("ADD_BRAM", true)
       }
       if (site(UseFlash)) {
-        entries += AddrMapEntry("flash", MemSize(1<<24, 1<<24, MemAttr(AddrMapProt.RWX)))
+        entries += AddrMapEntry("flash", MemSize(1<<24, 1<<24, MemAttr(AddrMapProt.RX)))
           Dump("ADD_FLASH", true)
       }
       if (site(UseHost)) {

--- a/src/main/verilog/chip_top.sv
+++ b/src/main/verilog/chip_top.sv
@@ -64,6 +64,8 @@ module chip_top
 `ifdef ADD_UART_IO
    input         rxd,
    output        txd,
+   output        rts,
+   input         cts,
 `endif
 
 `ifdef ADD_SPI
@@ -212,10 +214,13 @@ module chip_top
  `ifdef NEXYS4_COMMON
    //clock generator
    logic mig_sys_clk, clk_locked;
+   logic clk_io_uart; // UART IO clock for debug
+
    clk_wiz_0 clk_gen
      (
       .clk_in1     ( clk_p         ), // 100 MHz onboard
       .clk_out1    ( mig_sys_clk   ), // 200 MHz
+      .clk_io_uart ( clk_io_uart   ), // 60 MHz
       .resetn      ( rst_top       ),
       .locked      ( clk_locked    )
       );
@@ -719,11 +724,14 @@ module chip_top
      #(
        .N_CORES          ( `ROCKET_NTILES          ),
        .MAM_DATA_WIDTH   ( `ROCKET_MAM_IO_DWIDTH   ),
-       .MAM_ADDR_WIDTH   ( `ROCKET_PADDR_WIDTH     )
+       .MAM_ADDR_WIDTH   ( `ROCKET_PADDR_WIDTH     ),
+       .FREQ_CLK_IO      ( 60000000                ),
+       .UART_BAUD        ( 12000000                )
        )
    u_debug_system
      (
       .*,
+      .clk_io          ( clk_io_uart            ),
       .uart_irq        ( uart_irq               ),
       .uart_ar_addr    ( io_uart_lite.ar_addr   ),
       .uart_ar_ready   ( io_uart_lite.ar_ready  ),
@@ -743,6 +751,8 @@ module chip_top
       .uart_w_valid    ( io_uart_lite.w_valid   ),
       .rx              ( rxd                    ),
       .tx              ( txd                    ),
+      .rts             ( rts                    ),
+      .cts             ( cts                    ),
       .sys_rst         ( sys_rst                ),
       .cpu_rst         ( cpu_rst                ),
       .ring_out        ( debug_ring_start       ),
@@ -796,8 +806,8 @@ module chip_top
       .dsrn            ( 1'b1                   ),
       .sin             ( rxd                    ),
       .sout            ( txd                    ),
-      .ctsn            ( 1'b1                   ),
-      .rtsn            (                        )
+      .ctsn            ( cts                    ),
+      .rtsn            ( rts                    )
       );
 
   `else // !`ifdef ADD_UART

--- a/src/main/verilog/chip_top.sv
+++ b/src/main/verilog/chip_top.sv
@@ -26,6 +26,22 @@ module chip_top
    output        ddr_cs_n,
    output [7:0]  ddr_dm,
    output        ddr_odt,
+ `elsif NEXYS4_VIDEO
+   // DDR3 RAM
+   inout [15:0]  ddr_dq,
+   inout [1:0]   ddr_dqs_n,
+   inout [1:0]   ddr_dqs_p,
+   output [14:0] ddr_addr,
+   output [2:0]  ddr_ba,
+   output        ddr_ras_n,
+   output        ddr_cas_n,
+   output        ddr_we_n,
+   output        ddr_reset_n,
+   output        ddr_ck_n,
+   output        ddr_ck_p,
+   output        ddr_cke,
+   output [1:0]  ddr_dm,
+   output        ddr_odt,
  `elsif NEXYS4
    // DDR2 RAM
    inout [15:0]  ddr_dq,
@@ -193,7 +209,7 @@ module chip_top
       .m_axi_rready         ( mem_mig_nasti.r_ready    )
       );
 
- `ifdef NEXYS4
+ `ifdef NEXYS4_COMMON
    //clock generator
    logic mig_sys_clk, clk_locked;
    clk_wiz_0 clk_gen
@@ -203,7 +219,7 @@ module chip_top
       .resetn      ( rst_top       ),
       .locked      ( clk_locked    )
       );
- `endif //  `ifdef NEXYS4
+ `endif //  `ifdef NEXYS4_COMMON
 
    // DRAM controller
    mig_7series_0 dram_ctl
@@ -226,6 +242,24 @@ module chip_top
       .ddr3_ck_n            ( ddr_ck_n               ),
       .ddr3_cke             ( ddr_cke                ),
       .ddr3_cs_n            ( ddr_cs_n               ),
+      .ddr3_dm              ( ddr_dm                 ),
+      .ddr3_odt             ( ddr_odt                ),
+ `elsif NEXYS4_VIDEO
+      .sys_clk_i            ( mig_sys_clk            ),
+      .sys_rst              ( clk_locked             ),
+      .ui_addn_clk_0        ( clk                    ),
+      .ddr3_addr            ( ddr_addr               ),
+      .ddr3_ba              ( ddr_ba                 ),
+      .ddr3_cas_n           ( ddr_cas_n              ),
+      .ddr3_ck_n            ( ddr_ck_n               ),
+      .ddr3_ck_p            ( ddr_ck_p               ),
+      .ddr3_cke             ( ddr_cke                ),
+      .ddr3_ras_n           ( ddr_ras_n              ),
+      .ddr3_reset_n         ( ddr_reset_n            ),
+      .ddr3_we_n            ( ddr_we_n               ),
+      .ddr3_dq              ( ddr_dq                 ),
+      .ddr3_dqs_n           ( ddr_dqs_n              ),
+      .ddr3_dqs_p           ( ddr_dqs_p              ),
       .ddr3_dm              ( ddr_dm                 ),
       .ddr3_odt             ( ddr_odt                ),
  `elsif NEXYS4

--- a/src/main/verilog/config.vh
+++ b/src/main/verilog/config.vh
@@ -53,6 +53,14 @@
    `define ADD_PHY_DDR
   `endif
 
- `endif
+  `ifdef NEXYS4_VIDEO
+   `define NEXYS4_COMMON
+  `endif
+
+  `ifdef NEXYS4
+   `define NEXYS4_COMMON
+  `endif
+
+`endif
 
 `endif

--- a/src/test/cxx/veri/veri_top.cc
+++ b/src/test/cxx/veri/veri_top.cc
@@ -1,7 +1,9 @@
 // See LICENSE for license details.
 
 #include <verilated.h>
-#include <verilated_vcd_c.h>
+#ifdef TRACE_VCD
+ #include <verilated_vcd_c.h>
+#endif
 #include "Vchip_top.h"
 #include "globals.h"
 #include "dpi_ram_behav.h"
@@ -53,12 +55,14 @@ int main(int argc, char** argv) {
   top->rst_top = 1;
 
   // VCD dump
+#ifdef TRACE_VCD
   VerilatedVcdC* vcd = new VerilatedVcdC;
   if(vcd_enable) {
     Verilated::traceEverOn(true);
     top->trace(vcd, 99);
     vcd->open(vcd_name.c_str());
   }
+#endif
 
   top->eval();
   
@@ -84,7 +88,9 @@ int main(int argc, char** argv) {
 
     top->eval();
     if((main_time % 10) == 0) memory_controller->step();
+#ifdef TRACE_VCD
     if(vcd_enable) vcd->dump(main_time);       // do the dump
+#endif
 
     if(main_time < 140)
       main_time++;
@@ -96,7 +102,9 @@ int main(int argc, char** argv) {
   }
 
   top->final();
+#ifdef TRACE_VCD
   if(vcd_enable) vcd->close();
+#endif
 
   delete top;
   memory_model_close();

--- a/vsim/Makefile
+++ b/vsim/Makefile
@@ -128,42 +128,51 @@ veri_flags = \
 	+incdir+$(base_dir)/socip/nasti \
 	--top-module $(tb_top) \
 	--unroll-count 256 \
-	--trace \
+    --output-split 80000 \
+	--output-split-cfuncs 10000 \
 	-Wno-lint -Wno-style -Wno-STMTDLY -Wno-ASSIGNIN\
 	-CFLAGS "-std=c++11" \
 	-CFLAGS "-I$(base_dir)/src/test/cxx/common -I$(base_dir)/src/test/cxx/veri -I$(glip_dir)/backend_tcp/logic/dpi" \
 	-LDFLAGS "-pthread" \
 	--exe \
-	--Mdir $(sim_dir)/verilator
 
 # remove optimization if compilation takes too long or run out of memory
-#veri_opt_flags = -O3 -CFLAGS "-O1"
-veri_opt_flags =
-
+veri_opt_flags = --Mdir $(sim_dir)/verilator.opt -O3 -CFLAGS "-O1"
+veri_norm_flags = --Mdir $(sim_dir)/verilator.norm -O1 -CFLAGS "-O0"
+veri_dbg_flags = --Mdir $(sim_dir)/verilator.debug --trace -O1 -CFLAGS "-g -DDELAY_EXIT -DVERBOSE_MEMOR -DTRACE_VCD"
 
 #--------------------------------------------------------------------
 # Build the simulator (verilator)
 #--------------------------------------------------------------------
-verilator: verilator.log
-verilator.log: $(lowrisc_srcs) $(lowrisc_headers) $(verilog_srcs) $(verilog_headers) $(test_verilog_srcs) $(test_cxx_srcs) $(test_cxx_headers)
-	rm -fr $(sim_dir)/verilator
-	$(veri) --cc $(lowrisc_srcs) $(verilog_srcs) $(test_verilog_srcs) $(test_cxx_srcs) $(veri_flags) $(veri_opt_flags) -o ../$(CONFIG)-sim 2>&1 | tee $@
+verilator: verilator.norm.log
+verilator.norm.log: $(lowrisc_srcs) $(lowrisc_headers) $(verilog_srcs) $(verilog_headers) $(test_verilog_srcs) $(test_cxx_srcs) $(test_cxx_headers)
+	rm -fr $(sim_dir)/verilator.norm
+	$(veri) --cc $(lowrisc_srcs) $(verilog_srcs) $(test_verilog_srcs) $(test_cxx_srcs) $(veri_flags) $(veri_norm_flags) -o ../$(CONFIG)-sim 2>&1 | tee $@
 
 sim: $(CONFIG)-sim
-$(CONFIG)-sim: verilator.log
-	cd verilator && make -f V$(tb_top).mk
+$(CONFIG)-sim: verilator.norm.log
+	VM_PARALLEL_BUILDS=1 $(MAKE) -C verilator.norm -f V$(tb_top).mk
 
 verilator.debug.log: $(lowrisc_srcs) $(lowrisc_headers) $(verilog_srcs) $(verilog_headers) $(test_verilog_srcs) $(test_cxx_srcs) $(test_cxx_headers)
-	rm -fr $(sim_dir)/verilator
-	$(veri) --cc $(lowrisc_srcs) $(verilog_srcs) $(test_verilog_srcs) $(test_cxx_srcs) $(veri_flags) -CFLAGS "-g -DDELAY_EXIT -DVERBOSE_MEMORY" -o ../$(CONFIG)-sim-debug | tee $@
+	rm -fr $(sim_dir)/verilator.debug
+	$(veri) --cc $(lowrisc_srcs) $(verilog_srcs) $(test_verilog_srcs) $(test_cxx_srcs) $(veri_flags) $(veri_dbg_flags) -o ../$(CONFIG)-sim-debug | tee $@
 
 sim-debug: $(CONFIG)-sim-debug
 $(CONFIG)-sim-debug: verilator.debug.log
-	cd verilator && make -f V$(tb_top).mk
+	VM_PARALLEL_BUILDS=1 $(MAKE) -C verilator.debug -f V$(tb_top).mk
 
-.PHONY: verilator sim
+verilator.opt.log: verilator.opt.log
+verilator.opt.log: $(lowrisc_srcs) $(lowrisc_headers) $(verilog_srcs) $(verilog_headers) $(test_verilog_srcs) $(test_cxx_srcs) $(test_cxx_headers)
+	rm -fr $(sim_dir)/verilator.opt
+	$(veri) --cc $(lowrisc_srcs) $(verilog_srcs) $(test_verilog_srcs) $(test_cxx_srcs) $(veri_flags) $(veri_norm_flags) -o ../$(CONFIG)-sim 2>&1 | tee $@
 
-junk += $(generated_dir) $(CONFIG)-sim verilator verilator.log $(CONFIG)-sim-debug verilator.debug.log
+sim: $(CONFIG)-opt
+$(CONFIG)-sim-opt: verilator.opt.log
+	VM_PARALLEL_BUILDS=1 $(MAKE) -C verilator.opt -f V$(tb_top).mk
+
+.PHONY: verilator sim sim-debug sim-opt
+
+junk += $(generated_dir) $(CONFIG)-sim verilator.norm verilator.norm.log $(CONFIG)-sim-debug verilator.debug verilator.debug.log $(CONFIG)-sim-opt verilator.opt verilator.opt.log
 
 #--------------------------------------------------------------------
 # Test cases

--- a/vsim/Makefile
+++ b/vsim/Makefile
@@ -166,7 +166,7 @@ verilator.opt.log: $(lowrisc_srcs) $(lowrisc_headers) $(verilog_srcs) $(verilog_
 	rm -fr $(sim_dir)/verilator.opt
 	$(veri) --cc $(lowrisc_srcs) $(verilog_srcs) $(test_verilog_srcs) $(test_cxx_srcs) $(veri_flags) $(veri_norm_flags) -o ../$(CONFIG)-sim 2>&1 | tee $@
 
-sim: $(CONFIG)-opt
+sim-opt: $(CONFIG)-sim-opt
 $(CONFIG)-sim-opt: verilator.opt.log
 	VM_PARALLEL_BUILDS=1 $(MAKE) -C verilator.opt -f V$(tb_top).mk
 


### PR DESCRIPTION
* Adding hardware flow control for debug UART on Nexys4-DDR board
* Increase debug UART baud rate to 12M
* optimizing Verilator compilation script to allow speed compilation with make -j support