### PR TITLE
Extend debug v0.3 with Zedboard support

### DIFF
--- a/set_env.sh
+++ b/set_env.sh
@@ -29,8 +29,10 @@ export PYTHONPATH=$OSD_ROOT/lib/python2.7/site-packages:$PYTHONPATH
 
 if [ -z $LD_LIBRARY_PATH ]; then
   export LD_LIBRARY_PATH=$OSD_ROOT/lib
+  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TOP/riscv/lib
 else
   export LD_LIBRARY_PATH=$OSD_ROOT/lib:$LD_LIBRARY_PATH
+  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TOP/riscv/lib
 fi
 
 export PATH=$OSD_ROOT/bin:$PATH

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -444,6 +444,13 @@ class With512MRamConfig extends Config (
   }
 )
 
+class With6BitTags extends Config(
+    (pname,site,here) => pname match {
+        case MIFTagBits => Dump("ROCKET_MEM_TAG_WIDTH", 6)
+        case IOTagBits => Dump("ROCKET_IO_TAG_WIDTH", 6)
+    }
+)
+
 class BasicFPGAConfig extends
     Config(new WithSPIConfig ++ new WithBootRAMConfig ++ new WithFlashConfig ++ new BaseConfig)
 
@@ -465,3 +472,5 @@ class Nexys4VideoConfig extends
 class Nexys4VideoDebugConfig extends
     Config(new With512MRamConfig ++ new FPGADebugConfig)
 
+class ZedConfig extends 
+    Config(new With6BitTags ++ new With128MRamConfig ++ new WithUARTConfig ++ new WithSPIConfig ++ new WithBootRAMConfig ++ new BaseConfig)

--- a/src/main/verilog/chip_top.sv
+++ b/src/main/verilog/chip_top.sv
@@ -4,129 +4,219 @@ import dii_package::dii_flit;
 
 `include "consts.vh"
 `include "dev_map.vh"
-`include "config.vh"
+`include "config.vh"  // For the definition of LOWRISC_IO_DAT_WIDTH
 
 module chip_top
-  (
+(
 `ifdef ADD_PHY_DDR
- `ifdef KC705
-   // DDR3 RAM
-   inout [63:0]  ddr_dq,
-   inout [7:0]   ddr_dqs_n,
-   inout [7:0]   ddr_dqs_p,
-   output [13:0] ddr_addr,
-   output [2:0]  ddr_ba,
-   output        ddr_ras_n,
-   output        ddr_cas_n,
-   output        ddr_we_n,
-   output        ddr_reset_n,
-   output        ddr_ck_n,
-   output        ddr_ck_p,
-   output        ddr_cke,
-   output        ddr_cs_n,
-   output [7:0]  ddr_dm,
-   output        ddr_odt,
- `elsif NEXYS4_VIDEO
-   // DDR3 RAM
-   inout [15:0]  ddr_dq,
-   inout [1:0]   ddr_dqs_n,
-   inout [1:0]   ddr_dqs_p,
-   output [14:0] ddr_addr,
-   output [2:0]  ddr_ba,
-   output        ddr_ras_n,
-   output        ddr_cas_n,
-   output        ddr_we_n,
-   output        ddr_reset_n,
-   output        ddr_ck_n,
-   output        ddr_ck_p,
-   output        ddr_cke,
-   output [1:0]  ddr_dm,
-   output        ddr_odt,
- `elsif NEXYS4
-   // DDR2 RAM
-   inout [15:0]  ddr_dq,
-   inout [1:0]   ddr_dqs_n,
-   inout [1:0]   ddr_dqs_p,
-   output [12:0] ddr_addr,
-   output [2:0]  ddr_ba,
-   output        ddr_ras_n,
-   output        ddr_cas_n,
-   output        ddr_we_n,
-   output        ddr_ck_n,
-   output        ddr_ck_p,
-   output        ddr_cke,
-   output        ddr_cs_n,
-   output [1:0]  ddr_dm,
-   output        ddr_odt,
- `endif
+  `ifdef ZED
+    // RAM ACCESS THROUGH PS7's HP0 -> MEMCNT
+    output [31:0] mem_nasti_dram_araddr,
+    output  [1:0] mem_nasti_dram_arburst,
+    output  [3:0] mem_nasti_dram_arcache,
+    output  [5:0] mem_nasti_dram_arid,
+    output  [7:0] mem_nasti_dram_arlen,
+    output        mem_nasti_dram_arlock,
+    output  [2:0] mem_nasti_dram_arprot,
+    output  [3:0] mem_nasti_dram_arqos,
+    input         mem_nasti_dram_arready,
+    output  [2:0] mem_nasti_dram_arsize,
+    output        mem_nasti_dram_arvalid,
+    output  [3:0] mem_nasti_dram_arregion,
+    output [31:0] mem_nasti_dram_awaddr,
+    output  [1:0] mem_nasti_dram_awburst,
+    output  [3:0] mem_nasti_dram_awcache,
+    output  [5:0] mem_nasti_dram_awid,
+    output  [7:0] mem_nasti_dram_awlen,
+    output        mem_nasti_dram_awlock,
+    output  [2:0] mem_nasti_dram_awprot,
+    output  [3:0] mem_nasti_dram_awqos,
+    input         mem_nasti_dram_awready,
+    output  [2:0] mem_nasti_dram_awsize,
+    output        mem_nasti_dram_awvalid,
+    output  [3:0] mem_nasti_dram_awregion,
+    input   [5:0] mem_nasti_dram_bid,
+    output        mem_nasti_dram_bready,
+    input   [1:0] mem_nasti_dram_bresp,
+    input         mem_nasti_dram_bvalid,
+    input  [63:0] mem_nasti_dram_rdata,
+    input   [5:0] mem_nasti_dram_rid,
+    input         mem_nasti_dram_rlast,
+    output        mem_nasti_dram_rready,
+    input   [1:0] mem_nasti_dram_rresp,
+    input         mem_nasti_dram_rvalid,
+    output [63:0] mem_nasti_dram_wdata,
+    output        mem_nasti_dram_wlast,
+    input         mem_nasti_dram_wready,
+    output  [7:0] mem_nasti_dram_wstrb,
+    output        mem_nasti_dram_wvalid,
+  `elsif KC705
+    // DDR3 RAM
+    inout  [63:0] ddr_dq,
+    inout   [7:0] ddr_dqs_n,
+    inout   [7:0] ddr_dqs_p,
+    output [13:0] ddr_addr,
+    output  [2:0] ddr_ba,
+    output        ddr_ras_n,
+    output        ddr_cas_n,
+    output        ddr_we_n,
+    output        ddr_reset_n,
+    output        ddr_ck_n,
+    output        ddr_ck_p,
+    output        ddr_cke,
+    output        ddr_cs_n,
+    output  [7:0] ddr_dm,
+    output        ddr_odt,
+  `elsif NEXYS4_VIDEO
+    // DDR3 RAM
+    inout  [15:0] ddr_dq,
+    inout   [1:0] ddr_dqs_n,
+    inout   [1:0] ddr_dqs_p,
+    output [14:0] ddr_addr,
+    output  [2:0] ddr_ba,
+    output        ddr_ras_n,
+    output        ddr_cas_n,
+    output        ddr_we_n,
+    output        ddr_reset_n,
+    output        ddr_ck_n,
+    output        ddr_ck_p,
+    output        ddr_cke,
+    output  [1:0] ddr_dm,
+    output        ddr_odt,
+  `elsif NEXYS4
+    // DDR2 RAM
+    inout  [15:0] ddr_dq,
+    inout   [1:0] ddr_dqs_n,
+    inout   [1:0] ddr_dqs_p,
+    output [12:0] ddr_addr,
+    output  [2:0] ddr_ba,
+    output        ddr_ras_n,
+    output        ddr_cas_n,
+    output        ddr_we_n,
+    output        ddr_ck_n,
+    output        ddr_ck_p,
+    output        ddr_cke,
+    output        ddr_cs_n,
+    output  [1:0] ddr_dm,
+    output        ddr_odt,
+  `endif
 `endif //  `ifdef ADD_DDR_IO
 
 `ifdef ADD_UART_IO
-   input         rxd,
-   output        txd,
-   output        rts,
-   input         cts,
+    input         rxd,
+    output        txd,
+    output        rts,
+    input         cts,
 `endif
 
 `ifdef ADD_SPI
-   inout         spi_cs,
-   inout         spi_sclk,
-   inout         spi_mosi,
-   inout         spi_miso,
-   output        sd_reset,
+    inout         spi_cs,
+    inout         spi_sclk,
+    inout         spi_mosi,
+    inout         spi_miso,
+    output        sd_reset,
 `endif
 
 `ifdef ADD_FLASH
-   inout         flash_ss,
-   inout [3:0]   flash_io,
+   inout          flash_ss,
+   inout    [3:0] flash_io,
 `endif
 
-   // clock and reset
-   input         clk_p,
-   input         clk_n,
-   input         rst_top
-   );
+    // clock and reset
+    input         clk_p,
+    input         clk_n,
+    input         rst_top
+);
 
-   genvar        i;
+    genvar        i;
 
-   // internal clock and reset signals
-   logic  clk, rst, rstn;
-   assign rst = !rstn;
+    // internal clock and reset signals
+    logic  clk, rst, rstn;
+    assign rst = !rstn;
 
-   // Debug controlled reset of the Rocket system
-   logic  sys_rst, cpu_rst;
+    // Debug controlled reset of the Rocket system
+    logic  sys_rst, cpu_rst;
 
-   // interrupt line
-   logic [63:0]                interrupt;
+    // interrupt line
+    logic [63:0]                interrupt;
 
-   /////////////////////////////////////////////////////////////
-   // NASTI/Lite on-chip interconnects
+    /////////////////////////////////////////////////////////////
+    // NASTI/Lite on-chip interconnects
 
-   // Rocket memory nasti bus
-   nasti_channel
+    // Rocket memory nasti bus
+    nasti_channel
      #(
-       .ID_WIDTH    ( `ROCKET_MEM_TAG_WIDTH ),
-       .ADDR_WIDTH  ( `ROCKET_PADDR_WIDTH   ),
-       .DATA_WIDTH  ( `ROCKET_MEM_DAT_WIDTH ))
-   mem_nasti();
+        .ID_WIDTH    ( `ROCKET_MEM_TAG_WIDTH ),
+        .ADDR_WIDTH  ( `ROCKET_PADDR_WIDTH   ),
+        .DATA_WIDTH  ( `ROCKET_MEM_DAT_WIDTH ))
+    mem_nasti();
 
 `ifdef ADD_PHY_DDR
 
-   // the NASTI bus for off-FPGA DRAM, converted to High frequency
-   nasti_channel   
-     #(
-       .ID_WIDTH    ( `ROCKET_MEM_TAG_WIDTH ),
-       .ADDR_WIDTH  ( `ROCKET_PADDR_WIDTH   ),
-       .DATA_WIDTH  ( `ROCKET_MEM_DAT_WIDTH ))
-   mem_mig_nasti();
+    // the NASTI bus for off-FPGA DRAM, converted to High frequency
+    nasti_channel
+      #(
+        .ID_WIDTH    ( `ROCKET_MEM_TAG_WIDTH ),
+        .ADDR_WIDTH  ( `ROCKET_PADDR_WIDTH   ),
+        .DATA_WIDTH  ( `ROCKET_MEM_DAT_WIDTH ))
+    mem_mig_nasti();
 
-   // MIG clock
-   logic mig_ui_clk, mig_ui_rst, mig_ui_rstn;
-   assign mig_ui_rstn = !mig_ui_rst;
+  `ifdef ZED
+    // Clock is generated by PS7, and reset as well.
+    // So there is no need to clock generator,
+    // just use the inputs to the module
+    assign clk = clk_p;
+    assign rstn = !rst_top;
 
-   // clock converter
-   axi_clock_converter_0 clk_conv
-     (
+    assign mem_nasti_dram_araddr       = mem_nasti.ar_addr      ;
+    assign mem_nasti_dram_arburst      = mem_nasti.ar_burst     ;
+    assign mem_nasti_dram_arcache      = mem_nasti.ar_cache     ;
+    assign mem_nasti_dram_arid         = mem_nasti.ar_id        ;
+    assign mem_nasti_dram_arlen        = mem_nasti.ar_len       ;
+    assign mem_nasti_dram_arlock       = mem_nasti.ar_lock      ;
+    assign mem_nasti_dram_arprot       = mem_nasti.ar_prot      ;
+    assign mem_nasti_dram_arqos        = mem_nasti.ar_qos       ;
+    assign mem_nasti_dram_arready      = mem_nasti.ar_ready     ;
+    assign mem_nasti_dram_arsize       = mem_nasti.ar_size      ;
+    assign mem_nasti_dram_arvalid      = mem_nasti.ar_valid     ;
+    assign mem_nasti_dram_arregion     = mem_nasti.ar_region    ;
+    assign mem_nasti_dram_awaddr       = mem_nasti.aw_addr      ;
+    assign mem_nasti_dram_awburst      = mem_nasti.aw_burst     ;
+    assign mem_nasti_dram_awcache      = mem_nasti.aw_cache     ;
+    assign mem_nasti_dram_awid         = mem_nasti.aw_id        ;
+    assign mem_nasti_dram_awlen        = mem_nasti.aw_len       ;
+    assign mem_nasti_dram_awlock       = mem_nasti.aw_lock      ;
+    assign mem_nasti_dram_awprot       = mem_nasti.aw_prot      ;
+    assign mem_nasti_dram_awqos        = mem_nasti.aw_qos       ;
+    assign mem_nasti_dram_awready      = mem_nasti.aw_ready     ;
+    assign mem_nasti_dram_awsize       = mem_nasti.aw_size      ;
+    assign mem_nasti_dram_awvalid      = mem_nasti.aw_valid     ;
+    assign mem_nasti_dram_awregion     = mem_nasti.aw_region    ;
+    assign mem_nasti_dram_bid          = mem_nasti.b_id         ;
+    assign mem_nasti_dram_bready       = mem_nasti.b_ready      ;
+    assign mem_nasti_dram_bresp        = mem_nasti.b_resp       ;
+    assign mem_nasti_dram_bvalid       = mem_nasti.b_valid      ;
+    assign mem_nasti_dram_rdata        = mem_nasti.r_data       ;
+    assign mem_nasti_dram_rid          = mem_nasti.r_id         ;
+    assign mem_nasti_dram_rlast        = mem_nasti.r_last       ;
+    assign mem_nasti_dram_rready       = mem_nasti.r_ready      ;
+    assign mem_nasti_dram_rresp        = mem_nasti.r_resp       ;
+    assign mem_nasti_dram_rvalid       = mem_nasti.r_valid      ;
+    assign mem_nasti_dram_wdata        = mem_nasti.w_data       ;
+    assign mem_nasti_dram_wlast        = mem_nasti.w_last       ;
+    assign mem_nasti_dram_wready       = mem_nasti.w_ready      ;
+    assign mem_nasti_dram_wstrb        = mem_nasti.w_strb       ;
+    assign mem_nasti_dram_wvalid       = mem_nasti.w_valid      ;
+
+  `else // !`ifdef ZED
+
+    // MIG clock
+    logic mig_ui_clk, mig_ui_rst, mig_ui_rstn;
+    assign mig_ui_rstn = !mig_ui_rst;
+
+    // clock converter
+    axi_clock_converter_0 clk_conv
+      (
       .s_axi_aclk           ( clk                      ),
       .s_axi_aresetn        ( rstn                     ),
       .s_axi_awid           ( mem_nasti.aw_id          ),
@@ -211,149 +301,151 @@ module chip_top
       .m_axi_rready         ( mem_mig_nasti.r_ready    )
       );
 
- `ifdef NEXYS4_COMMON
-   //clock generator
-   logic mig_sys_clk, clk_locked;
-   logic clk_io_uart; // UART IO clock for debug
+      `ifdef NEXYS4_COMMON
+        //clock generator
+        logic mig_sys_clk, clk_locked;
+        logic clk_io_uart; // UART IO clock for debug
 
-   clk_wiz_0 clk_gen
-     (
-      .clk_in1     ( clk_p         ), // 100 MHz onboard
-      .clk_out1    ( mig_sys_clk   ), // 200 MHz
-      .clk_io_uart ( clk_io_uart   ), // 60 MHz
-      .resetn      ( rst_top       ),
-      .locked      ( clk_locked    )
+        clk_wiz_0 clk_gen
+        (
+          .clk_in1     ( clk_p         ), // 100 MHz onboard
+          .clk_out1    ( mig_sys_clk   ), // 200 MHz
+          .clk_io_uart ( clk_io_uart   ), // 60 MHz
+          .resetn      ( rst_top       ),
+          .locked      ( clk_locked    )
+        );
+      `endif //  `ifdef NEXYS4_COMMON
+
+      // DRAM controller
+      mig_7series_0 dram_ctl
+      (
+        `ifdef KC705
+          .sys_clk_p            ( clk_p                  ),
+          .sys_clk_n            ( clk_n                  ),
+          .sys_rst              ( rst_top                ),
+          .ui_addn_clk_0        ( clk                    ),
+          .ddr3_dq              ( ddr_dq                 ),
+          .ddr3_dqs_n           ( ddr_dqs_n              ),
+          .ddr3_dqs_p           ( ddr_dqs_p              ),
+          .ddr3_addr            ( ddr_addr               ),
+          .ddr3_ba              ( ddr_ba                 ),
+          .ddr3_ras_n           ( ddr_ras_n              ),
+          .ddr3_cas_n           ( ddr_cas_n              ),
+          .ddr3_we_n            ( ddr_we_n               ),
+          .ddr3_reset_n         ( ddr_reset_n            ),
+          .ddr3_ck_p            ( ddr_ck_p               ),
+          .ddr3_ck_n            ( ddr_ck_n               ),
+          .ddr3_cke             ( ddr_cke                ),
+          .ddr3_cs_n            ( ddr_cs_n               ),
+          .ddr3_dm              ( ddr_dm                 ),
+          .ddr3_odt             ( ddr_odt                ),
+        `elsif NEXYS4_VIDEO
+          .sys_clk_i            ( mig_sys_clk            ),
+          .sys_rst              ( clk_locked             ),
+          .ui_addn_clk_0        ( clk                    ),
+          .ddr3_addr            ( ddr_addr               ),
+          .ddr3_ba              ( ddr_ba                 ),
+          .ddr3_cas_n           ( ddr_cas_n              ),
+          .ddr3_ck_n            ( ddr_ck_n               ),
+          .ddr3_ck_p            ( ddr_ck_p               ),
+          .ddr3_cke             ( ddr_cke                ),
+          .ddr3_ras_n           ( ddr_ras_n              ),
+          .ddr3_reset_n         ( ddr_reset_n            ),
+          .ddr3_we_n            ( ddr_we_n               ),
+          .ddr3_dq              ( ddr_dq                 ),
+          .ddr3_dqs_n           ( ddr_dqs_n              ),
+          .ddr3_dqs_p           ( ddr_dqs_p              ),
+          .ddr3_dm              ( ddr_dm                 ),
+          .ddr3_odt             ( ddr_odt                ),
+        `elsif NEXYS4
+          .sys_clk_i            ( mig_sys_clk            ),
+          .sys_rst              ( clk_locked             ),
+          .ui_addn_clk_0        ( clk                    ),
+          .device_temp_i        ( 0                      ),
+          .ddr2_dq              ( ddr_dq                 ),
+          .ddr2_dqs_n           ( ddr_dqs_n              ),
+          .ddr2_dqs_p           ( ddr_dqs_p              ),
+          .ddr2_addr            ( ddr_addr               ),
+          .ddr2_ba              ( ddr_ba                 ),
+          .ddr2_ras_n           ( ddr_ras_n              ),
+          .ddr2_cas_n           ( ddr_cas_n              ),
+          .ddr2_we_n            ( ddr_we_n               ),
+          .ddr2_ck_p            ( ddr_ck_p               ),
+          .ddr2_ck_n            ( ddr_ck_n               ),
+          .ddr2_cke             ( ddr_cke                ),
+          .ddr2_cs_n            ( ddr_cs_n               ),
+          .ddr2_dm              ( ddr_dm                 ),
+          .ddr2_odt             ( ddr_odt                ),
+        `endif // !`elsif NEXYS4
+          .ui_clk               ( mig_ui_clk             ),
+          .ui_clk_sync_rst      ( mig_ui_rst             ),
+          .mmcm_locked          ( rstn                   ),
+          .aresetn              ( rstn                   ), // AXI reset
+          .app_sr_req           ( 1'b0                   ),
+          .app_ref_req          ( 1'b0                   ),
+          .app_zq_req           ( 1'b0                   ),
+          .s_axi_awid           ( mem_mig_nasti.aw_id    ),
+          .s_axi_awaddr         ( mem_mig_nasti.aw_addr  ),
+          .s_axi_awlen          ( mem_mig_nasti.aw_len   ),
+          .s_axi_awsize         ( mem_mig_nasti.aw_size  ),
+          .s_axi_awburst        ( mem_mig_nasti.aw_burst ),
+          .s_axi_awlock         ( 1'b0                   ), // not supported in AXI4
+          .s_axi_awcache        ( mem_mig_nasti.aw_cache ),
+          .s_axi_awprot         ( mem_mig_nasti.aw_prot  ),
+          .s_axi_awqos          ( mem_mig_nasti.aw_qos   ),
+          .s_axi_awvalid        ( mem_mig_nasti.aw_valid ),
+          .s_axi_awready        ( mem_mig_nasti.aw_ready ),
+          .s_axi_wdata          ( mem_mig_nasti.w_data   ),
+          .s_axi_wstrb          ( mem_mig_nasti.w_strb   ),
+          .s_axi_wlast          ( mem_mig_nasti.w_last   ),
+          .s_axi_wvalid         ( mem_mig_nasti.w_valid  ),
+          .s_axi_wready         ( mem_mig_nasti.w_ready  ),
+          .s_axi_bid            ( mem_mig_nasti.b_id     ),
+          .s_axi_bresp          ( mem_mig_nasti.b_resp   ),
+          .s_axi_bvalid         ( mem_mig_nasti.b_valid  ),
+          .s_axi_bready         ( mem_mig_nasti.b_ready  ),
+          .s_axi_arid           ( mem_mig_nasti.ar_id    ),
+          .s_axi_araddr         ( mem_mig_nasti.ar_addr  ),
+          .s_axi_arlen          ( mem_mig_nasti.ar_len   ),
+          .s_axi_arsize         ( mem_mig_nasti.ar_size  ),
+          .s_axi_arburst        ( mem_mig_nasti.ar_burst ),
+          .s_axi_arlock         ( 1'b0                   ), // not supported in AXI4
+          .s_axi_arcache        ( mem_mig_nasti.ar_cache ),
+          .s_axi_arprot         ( mem_mig_nasti.ar_prot  ),
+          .s_axi_arqos          ( mem_mig_nasti.ar_qos   ),
+          .s_axi_arvalid        ( mem_mig_nasti.ar_valid ),
+          .s_axi_arready        ( mem_mig_nasti.ar_ready ),
+          .s_axi_rid            ( mem_mig_nasti.r_id     ),
+          .s_axi_rdata          ( mem_mig_nasti.r_data   ),
+          .s_axi_rresp          ( mem_mig_nasti.r_resp   ),
+          .s_axi_rlast          ( mem_mig_nasti.r_last   ),
+          .s_axi_rvalid         ( mem_mig_nasti.r_valid  ),
+          .s_axi_rready         ( mem_mig_nasti.r_ready  )
       );
- `endif //  `ifdef NEXYS4_COMMON
 
-   // DRAM controller
-   mig_7series_0 dram_ctl
-     (
- `ifdef KC705
-      .sys_clk_p            ( clk_p                  ),
-      .sys_clk_n            ( clk_n                  ),
-      .sys_rst              ( rst_top                ),
-      .ui_addn_clk_0        ( clk                    ),
-      .ddr3_dq              ( ddr_dq                 ),
-      .ddr3_dqs_n           ( ddr_dqs_n              ),
-      .ddr3_dqs_p           ( ddr_dqs_p              ),
-      .ddr3_addr            ( ddr_addr               ),
-      .ddr3_ba              ( ddr_ba                 ),
-      .ddr3_ras_n           ( ddr_ras_n              ),
-      .ddr3_cas_n           ( ddr_cas_n              ),
-      .ddr3_we_n            ( ddr_we_n               ),
-      .ddr3_reset_n         ( ddr_reset_n            ),
-      .ddr3_ck_p            ( ddr_ck_p               ),
-      .ddr3_ck_n            ( ddr_ck_n               ),
-      .ddr3_cke             ( ddr_cke                ),
-      .ddr3_cs_n            ( ddr_cs_n               ),
-      .ddr3_dm              ( ddr_dm                 ),
-      .ddr3_odt             ( ddr_odt                ),
- `elsif NEXYS4_VIDEO
-      .sys_clk_i            ( mig_sys_clk            ),
-      .sys_rst              ( clk_locked             ),
-      .ui_addn_clk_0        ( clk                    ),
-      .ddr3_addr            ( ddr_addr               ),
-      .ddr3_ba              ( ddr_ba                 ),
-      .ddr3_cas_n           ( ddr_cas_n              ),
-      .ddr3_ck_n            ( ddr_ck_n               ),
-      .ddr3_ck_p            ( ddr_ck_p               ),
-      .ddr3_cke             ( ddr_cke                ),
-      .ddr3_ras_n           ( ddr_ras_n              ),
-      .ddr3_reset_n         ( ddr_reset_n            ),
-      .ddr3_we_n            ( ddr_we_n               ),
-      .ddr3_dq              ( ddr_dq                 ),
-      .ddr3_dqs_n           ( ddr_dqs_n              ),
-      .ddr3_dqs_p           ( ddr_dqs_p              ),
-      .ddr3_dm              ( ddr_dm                 ),
-      .ddr3_odt             ( ddr_odt                ),
- `elsif NEXYS4
-      .sys_clk_i            ( mig_sys_clk            ),
-      .sys_rst              ( clk_locked             ),
-      .ui_addn_clk_0        ( clk                    ),
-      .device_temp_i        ( 0                      ),
-      .ddr2_dq              ( ddr_dq                 ),
-      .ddr2_dqs_n           ( ddr_dqs_n              ),
-      .ddr2_dqs_p           ( ddr_dqs_p              ),
-      .ddr2_addr            ( ddr_addr               ),
-      .ddr2_ba              ( ddr_ba                 ),
-      .ddr2_ras_n           ( ddr_ras_n              ),
-      .ddr2_cas_n           ( ddr_cas_n              ),
-      .ddr2_we_n            ( ddr_we_n               ),
-      .ddr2_ck_p            ( ddr_ck_p               ),
-      .ddr2_ck_n            ( ddr_ck_n               ),
-      .ddr2_cke             ( ddr_cke                ),
-      .ddr2_cs_n            ( ddr_cs_n               ),
-      .ddr2_dm              ( ddr_dm                 ),
-      .ddr2_odt             ( ddr_odt                ),
- `endif // !`elsif NEXYS4
-      .ui_clk               ( mig_ui_clk             ),
-      .ui_clk_sync_rst      ( mig_ui_rst             ),
-      .mmcm_locked          ( rstn                   ),
-      .aresetn              ( rstn                   ), // AXI reset
-      .app_sr_req           ( 1'b0                   ),
-      .app_ref_req          ( 1'b0                   ),
-      .app_zq_req           ( 1'b0                   ),
-      .s_axi_awid           ( mem_mig_nasti.aw_id    ),
-      .s_axi_awaddr         ( mem_mig_nasti.aw_addr  ),
-      .s_axi_awlen          ( mem_mig_nasti.aw_len   ),
-      .s_axi_awsize         ( mem_mig_nasti.aw_size  ),
-      .s_axi_awburst        ( mem_mig_nasti.aw_burst ),
-      .s_axi_awlock         ( 1'b0                   ), // not supported in AXI4
-      .s_axi_awcache        ( mem_mig_nasti.aw_cache ),
-      .s_axi_awprot         ( mem_mig_nasti.aw_prot  ),
-      .s_axi_awqos          ( mem_mig_nasti.aw_qos   ),
-      .s_axi_awvalid        ( mem_mig_nasti.aw_valid ),
-      .s_axi_awready        ( mem_mig_nasti.aw_ready ),
-      .s_axi_wdata          ( mem_mig_nasti.w_data   ),
-      .s_axi_wstrb          ( mem_mig_nasti.w_strb   ),
-      .s_axi_wlast          ( mem_mig_nasti.w_last   ),
-      .s_axi_wvalid         ( mem_mig_nasti.w_valid  ),
-      .s_axi_wready         ( mem_mig_nasti.w_ready  ),
-      .s_axi_bid            ( mem_mig_nasti.b_id     ),
-      .s_axi_bresp          ( mem_mig_nasti.b_resp   ),
-      .s_axi_bvalid         ( mem_mig_nasti.b_valid  ),
-      .s_axi_bready         ( mem_mig_nasti.b_ready  ),
-      .s_axi_arid           ( mem_mig_nasti.ar_id    ),
-      .s_axi_araddr         ( mem_mig_nasti.ar_addr  ),
-      .s_axi_arlen          ( mem_mig_nasti.ar_len   ),
-      .s_axi_arsize         ( mem_mig_nasti.ar_size  ),
-      .s_axi_arburst        ( mem_mig_nasti.ar_burst ),
-      .s_axi_arlock         ( 1'b0                   ), // not supported in AXI4
-      .s_axi_arcache        ( mem_mig_nasti.ar_cache ),
-      .s_axi_arprot         ( mem_mig_nasti.ar_prot  ),
-      .s_axi_arqos          ( mem_mig_nasti.ar_qos   ),
-      .s_axi_arvalid        ( mem_mig_nasti.ar_valid ),
-      .s_axi_arready        ( mem_mig_nasti.ar_ready ),
-      .s_axi_rid            ( mem_mig_nasti.r_id     ),
-      .s_axi_rdata          ( mem_mig_nasti.r_data   ),
-      .s_axi_rresp          ( mem_mig_nasti.r_resp   ),
-      .s_axi_rlast          ( mem_mig_nasti.r_last   ),
-      .s_axi_rvalid         ( mem_mig_nasti.r_valid  ),
-      .s_axi_rready         ( mem_mig_nasti.r_ready  )
-      );
+    `endif // !`ifdef ZED
 
-`else
+  `else // `ifdef ADD_PHY_DDR
 
-   assign clk = clk_p;
-   assign rstn = !rst_top;
+    assign clk = clk_p;
+    assign rstn = !rst_top;
 
-   nasti_ram_behav
-     #(
-       .ID_WIDTH     ( `ROCKET_MEM_TAG_WIDTH   ),
-       .ADDR_WIDTH   ( `ROCKET_PADDR_WIDTH     ),
-       .DATA_WIDTH   ( `ROCKET_MEM_DAT_WIDTH   ),
-       .USER_WIDTH   ( 1                )
-       )
-   ram_behav
-     (
+    nasti_ram_behav
+    #(
+      .ID_WIDTH     ( `ROCKET_MEM_TAG_WIDTH   ),
+      .ADDR_WIDTH   ( `ROCKET_PADDR_WIDTH     ),
+      .DATA_WIDTH   ( `ROCKET_MEM_DAT_WIDTH   ),
+      .USER_WIDTH   ( 1                )
+      )
+    ram_behav
+    (
       .clk           ( clk         ),
       .rstn          ( rstn        ),
       .nasti         ( mem_nasti   )
-      );
-`endif // !`ifdef ADD_PHY_DDR
+    );
+  `endif // !`ifdef ADD_PHY_DDR
 
-   /////////////////////////////////////////////////////////////
+  /////////////////////////////////////////////////////////////
    // IO space buses
 
    nasti_channel


### PR DESCRIPTION
Hello again, As Travis complaint about submodule changes in previous pull request, I left my fork for lowrisc-chip, take the original again. Hope it will work out this time. 

Recapitulating the commits here: Two commits for the Zedboard extension in files Configs.scala and chip_top.sv. The third commit is on set_env.sh file for adding riscv/lib folder to the lib path, as I observed make errors when building examples.

Kind Regards, 
Furkan 