### PR TITLE
fix compile error when change NTile to 2, the incoherent signal for c…

### DIFF
--- a/src/main/scala/LowRISCChip.scala
+++ b/src/main/scala/LowRISCChip.scala
@@ -177,7 +177,7 @@ class Top(topParams: Parameters) extends Module with HasTopLevelParameters {
   })))
 
   coherent_net.io.managers <> managerEndpoints.map(_.innerTL) :+ mmioManager.io.inner
-  managerEndpoints.foreach { _.incoherent := io.cpu_rst } // revise when tiles are reset separately
+  managerEndpoints.foreach { _.incoherent.foreach { _ := io.cpu_rst } } // revise when tiles are reset separately
 
   ////////////////////////////////////////////
   // the network between L2 and memory/tag cache


### PR DESCRIPTION
…oherence manager is per core.

**Far from ideal, but at least this allow compiling with NTile > 1**