### PR TITLE
Update README.md (docs, restructure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-# See LICENSE.Cambridge for license details.
-
 lowRISC chip
 ==============================================
 
-The root git repo for lowRISC development and FPGA
-demos.
+The root git repo for lowRISC development and FPGA demos.
+
+See LICENSE.Cambridge for license details.
 
 See the [documentation](https://www.lowrisc.org/docs/) for build instructions.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ lowRISC chip
 The root git repo for lowRISC development and FPGA
 demos.
 
+See the [documentation](https://www.lowrisc.org/docs/) for build instructions.
+
 [master] status: [![master build status](https://travis-ci.org/lowRISC/lowrisc-chip.svg?branch=master)](https://travis-ci.org/lowRISC/lowrisc-chip)
 
 [update] status: [![update build status](https://travis-ci.org/lowRISC/lowrisc-chip.svg?branch=update)](https://travis-ci.org/lowRISC/lowrisc-chip)


### PR DESCRIPTION
Adds a link to the lowRISC webpage documentation.
Also, took the opportunity to reorganize the README in a way that seemed more natural to me: the license notice is no longer a H1 header (which typically it just a title or similar), but instead is near the other pointers to more info.