### PR TITLE
Free up more blockrams for Ariane

### DIFF
--- a/fpga/src/ariane_xilinx.sv
+++ b/fpga/src/ariane_xilinx.sv
@@ -646,7 +646,7 @@ logic [ariane_soc::NumSources-1:0] irq_sources;
 
 `ifdef NEXYS4DDR
 `ifdef ARIANE_SHELL
-   localparam graphmax = 19;
+   localparam graphmax = 18;
 `elsif ROCKET_SHELL
    localparam graphmax = 20;
 `else


### PR DESCRIPTION
Ariane uses more blockrams in its core caches, due to bit-orientated memory architecture. This is a bottleneck on nexys4-ddr systems.
