### PR TITLE
Add FPGA programming top-level Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,30 @@ nexys4_ddr_ariane_new: $(KERNEL)
 nexys4_ddr_rocket_new: $(KERNEL)
 	make -C fpga BOARD=nexys4_ddr BITSIZE=0x400000 CPU=rocket COMPATIBLE="sifive,rocket0" BBL=$(root-dir)$< new newmcs
 
+genesys2_ariane_program: $(KERNEL)
+	make -C fpga BOARD=genesys2 CPU=ariane JTAG_PART="xc7k325t_0" program
+
+genesys2_rocket_program: $(KERNEL)
+	make -C fpga BOARD=genesys2 CPU=rocket JTAG_PART="xc7k325t_0" program
+
+nexys4_ddr_ariane_program: $(KERNEL)
+	make -C fpga BOARD=nexys4_ddr CPU=ariane JTAG_PART="xc7a100t_0" program
+
+nexys4_ddr_rocket_program: $(KERNEL)
+	make -C fpga BOARD=nexys4_ddr CPU=rocket JTAG_PART="xc7a100t_0" program
+
+genesys2_ariane_cfgmem: $(KERNEL)
+	make -C fpga BOARD=genesys2 CPU=ariane JTAG_PART="xc7k325t_0" JTAG_MEMORY="s25fl256sxxxxxx0-spi-x1_x2_x4" cfgmem
+
+genesys2_rocket_cfgmem: $(KERNEL)
+	make -C fpga BOARD=genesys2 CPU=rocket JTAG_PART="xc7k325t_0" JTAG_MEMORY="s25fl256sxxxxxx0-spi-x1_x2_x4" cfgmem
+
+nexys4_ddr_ariane_cfgmem: $(KERNEL)
+	make -C fpga BOARD=nexys4_ddr CPU=ariane JTAG_PART="xc7a100t_0" JTAG_MEMORY="s25fl128sxxxxxx0-spi-x1_x2_x4" cfgmem
+
+nexys4_ddr_rocket_cfgmem: $(KERNEL)
+	make -C fpga BOARD=nexys4_ddr CPU=rocket JTAG_PART="xc7a100t_0" JTAG_MEMORY="s25fl128sxxxxxx0-spi-x1_x2_x4" cfgmem
+
 sdcard-install: $(KERNEL) lowrisc-quickstart/rootfs.tar.xz
 	cp $< lowrisc-quickstart/boot.bin
 	make -C lowrisc-quickstart/ install USB=$(USB)

--- a/fpga/Makefile
+++ b/fpga/Makefile
@@ -48,7 +48,10 @@ $(ips): %.xci :
 mcs: $(mcs)
 
 program:
-	$(VIVADO) $(VIVADOFLAGS) -source scripts/program.tcl
+	env JTAG_PART="$(JTAG_PART)" JTAG_BITFILE="$(work-dir)/$(CPU)_xilinx.bit" $(VIVADO) -nojournal -nolog -mode batch -source scripts/program.tcl
+
+cfgmem:
+	env JTAG_PART="$(JTAG_PART)" JTAG_MCSFILE="$(work-dir)/$(CPU)_xilinx.mcs" $(VIVADO) -nojournal -nolog -mode batch -source scripts/program_cfgmem.tcl
 
 newmcs: $(work-dir)/$(CPU)_xilinx.new.mcs
 

--- a/fpga/scripts/cnvmem.v
+++ b/fpga/scripts/cnvmem.v
@@ -23,9 +23,9 @@ module cnvmem;
 	while ((i >= `vstrt) && (1'bx === ^mem[i]))
 	  i=i-16;
         last = (i+16);
-        if (last < first + 'H8000)
+        if (last <= first + 'H8000)
              last = first + 'H8000;
-        else if (last < first + 'H10000)
+        else if (last <= first + 'H10000)
              last = first + 'H10000;
         for (i = i+1; i < last; i=i+1)
           mem[i] = 0;

--- a/fpga/scripts/program.tcl
+++ b/fpga/scripts/program.tcl
@@ -18,9 +18,28 @@
 open_hw
 
 connect_hw_server -url localhost:3121
-open_hw_target {localhost:3121/xilinx_tcf/Digilent/200300A8CD43B}
-
-current_hw_device [get_hw_devices xc7k325t_0]
-set_property PROGRAM.FILE {work-fpga/$::env(BOARD)_$::env(CPU)/ariane_xilinx.bit} [get_hw_devices xc7k325t_0]
-program_hw_devices [get_hw_devices xc7k325t_0]
-refresh_hw_device [lindex [get_hw_devices xc7k325t_0] 0]
+set board ""
+set device $::env(JTAG_PART)
+puts $device
+set bit $::env(JTAG_BITFILE)
+foreach { target } [get_hw_targets] {
+    current_hw_target $target
+    open_hw_target
+    set devices [get_hw_devices]
+    puts $device
+    if { $devices == $device } {
+        set board [current_hw_target]
+        break
+    } else {
+        puts [format "%s %s" ignoring $devices]
+    }
+    close_hw_target
+}
+if { $board == "" } {
+    puts "Did not find board"
+    exit 1
+}
+current_hw_device $device
+set_property PROGRAM.FILE $bit [current_hw_device]
+program_hw_devices [current_hw_device]
+disconnect_hw_server

--- a/fpga/scripts/program_cfgmem.tcl
+++ b/fpga/scripts/program_cfgmem.tcl
@@ -6,28 +6,48 @@
 # Function:
 #   Download bitstream to QSPI
 
-set mcs [lindex $argv 1]
-set device [lindex $argv 0]
+open_hw
 
+connect_hw_server -url localhost:3121
+set board ""
+set device $::env(JTAG_PART)
+set mcs $::env(JTAG_MCSFILE)
+set memory $::env(JTAG_MEMORY)
 puts "CFGMEM: $mcs"
 puts "DEVICE: $device"
+puts "MEMORY: $memory"
 
-open_hw
-connect_hw_server
-open_hw_target
-current_hw_device [lindex [get_hw_devices] 0]
-refresh_hw_device -update_hw_probes false [lindex [get_hw_devices] 0]
-create_hw_cfgmem -hw_device [lindex [get_hw_devices] 0] -mem_dev  [lindex [get_cfgmem_parts {s25fl128sxxxxxx0-spi-x1_x2_x4}] 0]
+foreach { target } [get_hw_targets] {
+    current_hw_target $target
+    open_hw_target
+    set devices [get_hw_devices]
+    puts $device
+    if { $devices == $device } {
+        set board [current_hw_target]
+        break
+    } else {
+        puts [format "%s %s" ignoring $devices]
+    }
+    close_hw_target
+}
+if { $board == "" } {
+    puts "Did not find board"
+    exit 1
+}
+current_hw_device $device
+
+refresh_hw_device -update_hw_probes false $device
+create_hw_cfgmem -hw_device $device -mem_dev  [lindex [get_cfgmem_parts $memory] 0]
 set_property PROGRAM.BLANK_CHECK  0 [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0 ]]
 set_property PROGRAM.ERASE  1 [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0 ]]
 set_property PROGRAM.CFG_PROGRAM  1 [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0 ]]
 set_property PROGRAM.VERIFY  1 [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0 ]]
 set_property PROGRAM.CHECKSUM  0 [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0 ]]
-refresh_hw_device [lindex [get_hw_devices] 0]
+refresh_hw_device $device
 set_property PROGRAM.ADDRESS_RANGE  {use_file} [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0 ]]
-set_property PROGRAM.FILES [list $mcs] [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0]]
+set_property PROGRAM.FILES [list $mcs] [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0 ]]
 set_property PROGRAM.UNUSED_PIN_TERMINATION {pull-none} [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0 ]]
 startgroup 
-if {![string equal [get_property PROGRAM.HW_CFGMEM_TYPE  [lindex [get_hw_devices] 0]] [get_property MEM_TYPE [get_property CFGMEM_PART [get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0 ]]]]] }  { create_hw_bitstream -hw_device [lindex [get_hw_devices] 0] [get_property PROGRAM.HW_CFGMEM_BITFILE [ lindex [get_hw_devices] 0]]; program_hw_devices [lindex [get_hw_devices] 0]; }; 
+if {![string equal [get_property PROGRAM.HW_CFGMEM_TYPE  [lindex [get_hw_devices] 0 ]] [get_property MEM_TYPE [get_property CFGMEM_PART [get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0 ]]]]] }  { create_hw_bitstream -hw_device [lindex [get_hw_devices] 0 ] [get_property PROGRAM.HW_CFGMEM_BITFILE [ lindex [get_hw_devices] 0]]; program_hw_devices [lindex [get_hw_devices] 0 ]; }; 
 program_hw_cfgmem -hw_cfgmem [get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0 ]]
 endgroup


### PR DESCRIPTION
The FPGA programming needs generalizing to allow for the possibility of multiple development boards being connected