### PR TITLE
Update QEMU submodule for 0.6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/lowRISC/debian-riscv64.git
 [submodule "qemu"]
 	path = qemu
-	url = https://github.com/lowrisc/qemu.git
+	url = https://github.com/lowrisc/qemu-archive.git


### PR DESCRIPTION
Our QEMU fork was recently repurposed for OpenTitan work.

This PR updates the git submodule URL to the previous version. I haven't tested the chip with this version of QEMU.