### PR TITLE
[submodule] Point qemu to archived version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/lowRISC/debian-riscv64.git
 [submodule "qemu"]
 	path = qemu
-	url = https://github.com/lowrisc/qemu.git
+	url = https://github.com/lowrisc/qemu-archive.git


### PR DESCRIPTION
We recently moved our old qemu to qemu-archive. This is because we want to use the qemu repo for the more actively developed OpenTitan version. Updating this pointer should now fix the following error when recursively cloning this repository:
```
fatal: remote error: upload-pack: not our ref 7ae23bc1974f8738b5009125873e43e6a8b1d848
```